### PR TITLE
build: bump spring-boot-starter-parent 3.3.2 → 3.5.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <artifactId>spring-boot-starter-parent</artifactId>
     <groupId>org.springframework.boot</groupId>
     <relativePath/>
-    <version>3.3.2</version> <!-- lookup parent from repository -->
+    <version>3.5.14</version> <!-- lookup parent from repository -->
   </parent>
   <properties>
     <java.version>21</java.version>


### PR DESCRIPTION
Spring Boot 3.3.x reached OSS EOL on 2026-06-30; 3.5.14 is the latest 3.5.x stable line and remains supported.

Resolved transitives that matter for this project:
  - spring-boot-* 3.5.14
  - spring-webflux 6.2.18
  - reactor-netty-http 1.2.17 (covers CVE-2025-22227)

No source changes were needed — 3.3.x → 3.5.x is API-compatible for the WebFlux + reactor-netty surface this library uses. Local test-compile and unit tests pass against the new BOM.