### PR TITLE
refactor(metadata): use Spring MergedAnnotations for mapping resolution

### DIFF
--- a/src/main/java/com/nephren/raven/apiclient/aop/RequestMappingMetadataBuilder.java
+++ b/src/main/java/com/nephren/raven/apiclient/aop/RequestMappingMetadataBuilder.java
@@ -1,32 +1,26 @@
 package com.nephren.raven.apiclient.aop;
 
-import com.nephren.raven.apiclient.exception.RavenApiException;
 import com.nephren.raven.apiclient.properties.PropertiesHelper;
 import com.nephren.raven.apiclient.properties.RavenApiClientProperties;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -43,15 +37,6 @@ import reactor.core.publisher.Mono;
 
 @Slf4j
 public class RequestMappingMetadataBuilder {
-
-  private static final Class<?>[] mappingAnnotation = {
-      GetMapping.class,
-      PutMapping.class,
-      PostMapping.class,
-      PatchMapping.class,
-      DeleteMapping.class,
-      RequestMapping.class
-  };
 
   private final Map<String, MultiValueMap<String, String>> headers = new HashMap<>();
   private final Map<String, Integer> apiUrlPositions = new HashMap<>();
@@ -215,33 +200,17 @@ public class RequestMappingMetadataBuilder {
       Parameter[] parameters,
       Class<T> parameterAnnotationClass) {
     Map<String, Integer> parameterPosition = new HashMap<>();
-    for (int i = 0;
-        i < parameters.length;
-        i++) {
-      Parameter parameter = parameters[i];
-      T annotation = parameter.getAnnotation(parameterAnnotationClass);
-      if (annotation != null) {
-        String paramName = getParamName(annotation);
+    for (int i = 0; i < parameters.length; i++) {
+      MergedAnnotation<T> annotation =
+          MergedAnnotations.from(parameters[i]).get(parameterAnnotationClass);
+      if (annotation.isPresent()) {
+        String paramName = annotation.getString("name");
         if (!paramName.isEmpty()) {
           parameterPosition.put(paramName, i);
         }
       }
     }
     return parameterPosition;
-  }
-
-  private <T extends Annotation> String getParamName(T annotation) {
-    String paramName = "", paramValue = "";
-    try {
-      paramName = annotation.getClass().getMethod("name").invoke(annotation).toString();
-      paramValue =
-          annotation.getClass().getMethod("value").invoke(annotation).toString();
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new RavenApiException(
-          "#RavenApiClient RequestMappingMetadataBuilder failed to read parameter name from "
-              + "annotation " + annotation.annotationType().getName(), e);
-    }
-    return paramName.isEmpty() ? paramValue : paramName;
   }
 
   private void prepareResponseBodyClasses() {
@@ -309,55 +278,28 @@ public class RequestMappingMetadataBuilder {
     });
   }
 
+  /**
+   * Resolve the (possibly meta-annotated) {@link RequestMapping} on the given method into a
+   * {@link RavenRequestMapping}. Returns {@code null} if no mapping annotation is present.
+   *
+   * <p>Spring's {@link MergedAnnotations} follows meta-annotations and applies {@code @AliasFor}
+   * overrides, so {@code @GetMapping}, {@code @PostMapping}, etc. are resolved through their
+   * meta-annotated {@code @RequestMapping} with the correct {@code method} attribute populated.
+   */
   private RavenRequestMapping getRequestMappingAnnotation(Method method) {
-    for (Class annotation : mappingAnnotation) {
-      Annotation methodAnnotation = method.getAnnotation(annotation);
-      if (methodAnnotation != null) {
-        return getAnnotation(method, annotation);
-      }
+    MergedAnnotation<RequestMapping> annotation =
+        MergedAnnotations.from(method).get(RequestMapping.class);
+    if (!annotation.isPresent()) {
+      return null;
     }
-    return null;
-  }
-
-  private <T extends Annotation> RavenRequestMapping getAnnotation(
-      Method method, Class<T> annotationType) {
-    try {
-      T annotation = method.getAnnotation(annotationType);
-      String[] consumes =
-          (String[]) annotation.getClass().getMethod("consumes").invoke(annotation);
-      String[] produces =
-          (String[]) annotation.getClass().getMethod("produces").invoke(annotation);
-      String[] headers = (String[]) annotation.getClass().getMethod("headers").invoke(annotation);
-      String[] path = (String[]) annotation.getClass().getMethod("path").invoke(annotation);
-      String[] value = (String[]) annotation.getClass().getMethod("value").invoke(annotation);
-      RequestMethod[] requestMethod = getRequestMethod(annotation, annotationType);
-      return RavenRequestMapping.builder()
-          .consumes(consumes)
-          .produces(produces)
-          .headers(headers)
-          .path(path)
-          .value(value)
-          .method(requestMethod)
-          .build();
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new RavenApiException(
-          "#RavenApiClient getAnnotation failed to read attributes from "
-              + annotationType.getName() + " on method " + method.getName(), e);
-    }
-  }
-
-  private <T extends Annotation> RequestMethod[] getRequestMethod(T annotation,
-      Class<T> annotationType)
-      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    return switch (annotationType.getSimpleName()) {
-      case "PutMapping" -> List.of(RequestMethod.PUT).toArray(new RequestMethod[0]);
-      case "PostMapping" -> List.of(RequestMethod.POST).toArray(new RequestMethod[0]);
-      case "PatchMapping" -> List.of(RequestMethod.PATCH).toArray(new RequestMethod[0]);
-      case "DeleteMapping" -> List.of(RequestMethod.DELETE).toArray(new RequestMethod[0]);
-      case "RequestMapping" ->
-          (RequestMethod[]) annotation.getClass().getMethod("method").invoke(annotation);
-      default -> List.of(RequestMethod.GET).toArray(new RequestMethod[0]);
-    };
+    return RavenRequestMapping.builder()
+        .consumes(annotation.getStringArray("consumes"))
+        .produces(annotation.getStringArray("produces"))
+        .headers(annotation.getStringArray("headers"))
+        .path(annotation.getStringArray("path"))
+        .value(annotation.getStringArray("value"))
+        .method(annotation.getEnumArray("method", RequestMethod.class))
+        .build();
   }
 
   private String getDefaultContentType() {

--- a/src/test/java/com/nephren/raven/apiclient/unit/RequestMappingMetadataBuilderTest.java
+++ b/src/test/java/com/nephren/raven/apiclient/unit/RequestMappingMetadataBuilderTest.java
@@ -27,10 +27,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import reactor.core.publisher.Mono;
 
 /**
- * Locks in the {@link MergedAnnotations}-based metadata resolution introduced in tier 2 B2:
- * meta-annotated shortcuts ({@code @GetMapping} et al.) must yield the same merged
- * {@code @RequestMapping} attributes as a directly declared {@code @RequestMapping}, and
- * parameter annotations with {@code @AliasFor("name") value} must resolve via either alias.
+ * Locks in the {@link org.springframework.core.annotation.MergedAnnotations}-based metadata
+ * resolution introduced in tier 2 B2: meta-annotated shortcuts ({@code @GetMapping} et al.)
+ * must yield the same merged {@code @RequestMapping} attributes as a directly declared
+ * {@code @RequestMapping}, and parameter annotations with {@code @AliasFor("name") value} must
+ * resolve via either alias.
  */
 class RequestMappingMetadataBuilderTest {
 

--- a/src/test/java/com/nephren/raven/apiclient/unit/RequestMappingMetadataBuilderTest.java
+++ b/src/test/java/com/nephren/raven/apiclient/unit/RequestMappingMetadataBuilderTest.java
@@ -1,0 +1,145 @@
+package com.nephren.raven.apiclient.unit;
+
+import com.nephren.raven.apiclient.aop.RequestMappingMetadata;
+import com.nephren.raven.apiclient.aop.RequestMappingMetadataBuilder;
+import com.nephren.raven.apiclient.properties.RavenApiClientProperties;
+import java.util.HashMap;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import reactor.core.publisher.Mono;
+
+/**
+ * Locks in the {@link MergedAnnotations}-based metadata resolution introduced in tier 2 B2:
+ * meta-annotated shortcuts ({@code @GetMapping} et al.) must yield the same merged
+ * {@code @RequestMapping} attributes as a directly declared {@code @RequestMapping}, and
+ * parameter annotations with {@code @AliasFor("name") value} must resolve via either alias.
+ */
+class RequestMappingMetadataBuilderTest {
+
+  interface SampleClient {
+
+    @GetMapping(value = "/get/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    Mono<ResponseEntity<String>> get(
+        @PathVariable("id") String id,
+        @RequestHeader("X-Trace-Id") String trace,
+        @RequestParam("filter") String filter,
+        @CookieValue("session") String session);
+
+    @PostMapping(value = "/post", consumes = MediaType.APPLICATION_JSON_VALUE,
+        headers = {"X-Static=value"})
+    Mono<ResponseEntity<String>> post();
+
+    @PutMapping("/put")
+    Mono<ResponseEntity<String>> put();
+
+    @PatchMapping("/patch")
+    Mono<ResponseEntity<String>> patch();
+
+    @DeleteMapping("/delete")
+    Mono<ResponseEntity<String>> delete();
+
+    @RequestMapping(value = "/explicit", method = RequestMethod.GET)
+    Mono<ResponseEntity<String>> explicit();
+
+    // RequestParam.value is @AliasFor("name") — verify either alias is read.
+    @GetMapping("/alias")
+    Mono<ResponseEntity<String>> alias(@RequestParam(value = "q") String q);
+
+    // No mapping annotation — must be filtered out.
+    Mono<ResponseEntity<String>> noMapping();
+  }
+
+  private RequestMappingMetadata metadata;
+
+  @BeforeEach
+  void buildMetadata() {
+    ApplicationContext ctx = Mockito.mock(ApplicationContext.class);
+    RavenApiClientProperties props = new RavenApiClientProperties();
+    Map<String, RavenApiClientProperties.ApiClientConfigProperties> configs = new HashMap<>();
+    configs.put("sample", new RavenApiClientProperties.ApiClientConfigProperties());
+    props.setConfigs(configs);
+    Mockito.when(ctx.getBean(RavenApiClientProperties.class)).thenReturn(props);
+
+    metadata = new RequestMappingMetadataBuilder(ctx, SampleClient.class, "sample").build();
+  }
+
+  @Test
+  void prepareMethods_includesAllAnnotated_andSkipsUnannotated() {
+    Assertions.assertThat(metadata.getMethods()).containsKeys(
+        "get", "post", "put", "patch", "delete", "explicit", "alias");
+    Assertions.assertThat(metadata.getMethods()).doesNotContainKey("noMapping");
+  }
+
+  @Test
+  void shortcutAnnotations_resolveToCorrectHttpMethod() {
+    Assertions.assertThat(metadata.getRequestMethods())
+        .containsEntry("get", RequestMethod.GET)
+        .containsEntry("post", RequestMethod.POST)
+        .containsEntry("put", RequestMethod.PUT)
+        .containsEntry("patch", RequestMethod.PATCH)
+        .containsEntry("delete", RequestMethod.DELETE)
+        .containsEntry("explicit", RequestMethod.GET);
+  }
+
+  @Test
+  void getMapping_path_isResolved() {
+    Assertions.assertThat(metadata.getPaths()).containsEntry("get", "/get/{id}");
+    Assertions.assertThat(metadata.getPaths()).containsEntry("explicit", "/explicit");
+  }
+
+  @Test
+  void produces_isMappedTo_AcceptHeader() {
+    Assertions.assertThat(metadata.getHeaders().get("get").getFirst(HttpHeaders.ACCEPT))
+        .isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+  }
+
+  @Test
+  void consumes_isMappedTo_ContentTypeHeader_andContentTypes() {
+    Assertions.assertThat(metadata.getHeaders().get("post").getFirst(HttpHeaders.CONTENT_TYPE))
+        .isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+    Assertions.assertThat(metadata.getContentTypes())
+        .containsEntry("post", MediaType.APPLICATION_JSON_VALUE);
+  }
+
+  @Test
+  void staticHeaderEntries_areInjected() {
+    Assertions.assertThat(metadata.getHeaders().get("post").getFirst("X-Static"))
+        .isEqualTo("value");
+  }
+
+  @Test
+  void parameterAnnotations_resolveByName() {
+    Assertions.assertThat(metadata.getPathVariablePositions().get("get"))
+        .containsEntry("id", 0);
+    Assertions.assertThat(metadata.getHeaderParamPositions().get("get"))
+        .containsEntry("X-Trace-Id", 1);
+    Assertions.assertThat(metadata.getQueryParamPositions().get("get"))
+        .containsEntry("filter", 2);
+    Assertions.assertThat(metadata.getCookieParamPositions().get("get"))
+        .containsEntry("session", 3);
+  }
+
+  @Test
+  void requestParamValueAlias_isResolvedAsName() {
+    Assertions.assertThat(metadata.getQueryParamPositions().get("alias"))
+        .containsEntry("q", 0);
+  }
+}


### PR DESCRIPTION
Replace the brittle reflection-by-method-name approach in RequestMappingMetadataBuilder with Spring's MergedAnnotations API.

Before, attribute reads were done via:
  annotation.getClass().getMethod("consumes").invoke(annotation)
…which is fragile to any internal Spring annotation API change, requires hand-rolled per-shortcut switch (PutMapping/PostMapping/…), and ignores @AliasFor relationships.

MergedAnnotations.from(method).get(RequestMapping.class) follows meta-annotations and applies @AliasFor automatically, so:
  - @GetMapping/@PostMapping/@PutMapping/@PatchMapping/@DeleteMapping are resolved through their @RequestMapping meta-annotation with the correct method attribute populated, removing the need for the hardcoded mappingAnnotation array, the simple-name switch in getRequestMethod, and the per-shortcut iteration.
  - Parameter annotations like @RequestParam read through MergedAnnotations.from(parameter).get(RequestParam.class), so the name/value alias is resolved natively — getString("name") returns whichever alias the user set, eliminating the manual fallback in getParamName.

Net diff: -85/+27 LOC; deletes the mappingAnnotation constant, getAnnotation, getRequestMethod, getParamName, and three reflection exception branches.

Adds RequestMappingMetadataBuilderTest covering: shortcut → HTTP method resolution, path/produces/consumes/headers extraction, parameter name resolution for all four parameter annotations, RequestParam.value alias, and that unannotated methods are filtered out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal request mapping metadata resolution mechanism for better code maintainability.

* **Tests**
  * Added comprehensive test coverage for request mapping metadata handling, including validation of HTTP method resolution, URL path mapping, header processing, and parameter metadata extraction across annotation types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->