### PR TITLE
fix(interceptor): preserve generic type for List<POJO> response bodies

### DIFF
--- a/src/main/java/com/nephren/raven/apiclient/aop/RavenApiClientMethodInterceptor.java
+++ b/src/main/java/com/nephren/raven/apiclient/aop/RavenApiClientMethodInterceptor.java
@@ -297,9 +297,12 @@ public class RavenApiClientMethodInterceptor implements InitializingBean, Method
     if (ResponseEntity.class.equals(parameterizedType.getRawType())) {
       return handleResponseEntity(client, parameterizedType);
     } else {
+      // Pass the full parameterized type (e.g. List<Foo>) so Jackson preserves the
+      // generic type argument; previously only the raw type (List.class) was passed,
+      // which silently degraded deserialization to LinkedHashMap for POJO elements.
       return client.flatMap(
           c -> c.retrieve()
-              .bodyToMono(ParameterizedTypeReference.forType(parameterizedType.getRawType())));
+              .bodyToMono(ParameterizedTypeReference.forType(parameterizedType)));
     }
   }
 
@@ -330,9 +333,12 @@ public class RavenApiClientMethodInterceptor implements InitializingBean, Method
 
   private Mono handleListResponseSpec(Mono<WebClient.ResponseSpec> responseSpec,
       ParameterizedType parameterizedType) {
+    // parameterizedType here is the inner List<X> from ResponseEntity<List<X>>; pass it
+    // wholesale so the response body deserializes into List<X>, not List<LinkedHashMap>.
+    // Previously only the element type X was passed, which produced ResponseEntity<X>
+    // and silently coerced JSON arrays of POJOs to raw structures.
     return responseSpec.flatMap(respEntity -> respEntity.toEntity(
-        ParameterizedTypeReference.forType(
-            parameterizedType.getActualTypeArguments()[0])));
+        ParameterizedTypeReference.forType(parameterizedType)));
   }
 
   private Mono handleSingleResponseSpec(Mono<WebClient.ResponseSpec> responseSpec, Type type) {

--- a/src/test/java/com/nephren/raven/apiclient/RavenApiClientGenericResponseTests.java
+++ b/src/test/java/com/nephren/raven/apiclient/RavenApiClientGenericResponseTests.java
@@ -1,0 +1,63 @@
+package com.nephren.raven.apiclient;
+
+import com.nephren.raven.apiclient.serviceExample.model.ServerResponseBody;
+import com.nephren.raven.apiclient.serviceExample.service.GETClientService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import reactor.test.StepVerifier;
+
+/**
+ * Verifies that {@code Mono<List<POJO>>} and {@code Mono<ResponseEntity<List<POJO>>>} return
+ * shapes deserialize properly into typed POJO elements rather than degrading to
+ * {@code List<LinkedHashMap>} — the regression fixed in tier 2 B3.
+ *
+ * <p>Before the fix the interceptor passed only the raw type ({@code List.class}) or only the
+ * inner element type ({@code POJO.class}) to {@link
+ * org.springframework.core.ParameterizedTypeReference#forType}, erasing the generic parameter
+ * Jackson needs to drive POJO deserialization. With the existing {@code List<String>} tests
+ * this was masked because Jackson maps JSON strings to {@link String} natively; POJO elements
+ * surface the bug.</p>
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@AutoConfigureWebTestClient
+class RavenApiClientGenericResponseTests {
+
+  private final GETClientService getClientService;
+
+  @Autowired
+  public RavenApiClientGenericResponseTests(GETClientService getClientService) {
+    this.getClientService = getClientService;
+  }
+
+  @Test
+  void monoListPojo_deserializesIntoTypedPojoElements() {
+    StepVerifier.create(getClientService.getRequestListPojoNoEntity())
+        .assertNext(list -> {
+          org.assertj.core.api.Assertions.assertThat(list).hasSize(2);
+          org.assertj.core.api.Assertions.assertThat(list.get(0))
+              .isInstanceOf(ServerResponseBody.class)
+              .extracting(ServerResponseBody::getMessage).isEqualTo("first");
+          org.assertj.core.api.Assertions.assertThat(list.get(1))
+              .extracting(ServerResponseBody::getMessage).isEqualTo("second");
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  void monoResponseEntityListPojo_deserializesIntoTypedPojoElements() {
+    StepVerifier.create(getClientService.getRequestListPojo())
+        .assertNext(entity -> {
+          org.assertj.core.api.Assertions.assertThat(entity.getStatusCode().is2xxSuccessful())
+              .isTrue();
+          org.assertj.core.api.Assertions.assertThat(entity.getBody()).hasSize(2);
+          org.assertj.core.api.Assertions.assertThat(entity.getBody().get(0))
+              .isInstanceOf(ServerResponseBody.class)
+              .extracting(ServerResponseBody::getMessage).isEqualTo("first");
+          org.assertj.core.api.Assertions.assertThat(entity.getBody().get(1))
+              .extracting(ServerResponseBody::getMessage).isEqualTo("second");
+        })
+        .verifyComplete();
+  }
+}

--- a/src/test/java/com/nephren/raven/apiclient/serviceExample/client/GETExampleClient.java
+++ b/src/test/java/com/nephren/raven/apiclient/serviceExample/client/GETExampleClient.java
@@ -1,6 +1,7 @@
 package com.nephren.raven.apiclient.serviceExample.client;
 
 import com.nephren.raven.apiclient.annotation.RavenApiClient;
+import com.nephren.raven.apiclient.serviceExample.model.ServerResponseBody;
 import java.util.List;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -85,5 +86,13 @@ public interface GETExampleClient {
   @GetMapping(value = "/getRequest-ISE",
       produces = MediaType.APPLICATION_JSON_VALUE)
   Mono<String> getRequestISEWithoutResponseEntity();
+
+  @GetMapping(value = "/getRequest-listPojo",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  Mono<ResponseEntity<List<ServerResponseBody>>> getRequestListPojo();
+
+  @GetMapping(value = "/getRequest-listPojo-no-entity",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  Mono<List<ServerResponseBody>> getRequestListPojoNoEntity();
 
 }

--- a/src/test/java/com/nephren/raven/apiclient/serviceExample/server/GETServerController.java
+++ b/src/test/java/com/nephren/raven/apiclient/serviceExample/server/GETServerController.java
@@ -1,5 +1,6 @@
 package com.nephren.raven.apiclient.serviceExample.server;
 
+import com.nephren.raven.apiclient.serviceExample.model.ServerResponseBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -78,6 +79,20 @@ public class GETServerController {
   @GetMapping(path = "/getRequest-listWithoutResponseEntity")
   public Mono<List<String>> getRequestListWithoutResponseEntity() {
     return Mono.just(List.of("Hello", "こんいちわ", "Hola", "Bonjour", "Hallo"));
+  }
+
+  @GetMapping(path = "/getRequest-listPojo")
+  public Mono<ResponseEntity<List<ServerResponseBody>>> getRequestListPojo() {
+    return Mono.just(ResponseEntity.ok(List.of(
+        ServerResponseBody.builder().message("first").build(),
+        ServerResponseBody.builder().message("second").build())));
+  }
+
+  @GetMapping(path = "/getRequest-listPojo-no-entity")
+  public Mono<List<ServerResponseBody>> getRequestListPojoNoEntity() {
+    return Mono.just(List.of(
+        ServerResponseBody.builder().message("first").build(),
+        ServerResponseBody.builder().message("second").build()));
   }
 
 }

--- a/src/test/java/com/nephren/raven/apiclient/serviceExample/service/GETClientService.java
+++ b/src/test/java/com/nephren/raven/apiclient/serviceExample/service/GETClientService.java
@@ -4,6 +4,7 @@ import com.nephren.raven.apiclient.serviceExample.client.EmptyExampleClient;
 import com.nephren.raven.apiclient.serviceExample.client.ExampleClientWithFallback;
 import com.nephren.raven.apiclient.serviceExample.client.ExampleClientWithOtherFallback;
 import com.nephren.raven.apiclient.serviceExample.client.GETExampleClient;
+import com.nephren.raven.apiclient.serviceExample.model.ServerResponseBody;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -114,6 +115,14 @@ public class GETClientService {
 
   public Mono<String> getRequestISEWithoutResponseEntity() {
     return getExampleClient.getRequestISEWithoutResponseEntity();
+  }
+
+  public Mono<ResponseEntity<List<ServerResponseBody>>> getRequestListPojo() {
+    return getExampleClient.getRequestListPojo();
+  }
+
+  public Mono<List<ServerResponseBody>> getRequestListPojoNoEntity() {
+    return getExampleClient.getRequestListPojoNoEntity();
   }
 
 }


### PR DESCRIPTION
Two related bugs in handleParameterizedType / handleListResponseSpec erased the generic type argument before handing off to Jackson:

1. Mono<List<X>> path passed parameterizedType.getRawType() (i.e., List.class) to ParameterizedTypeReference.forType, so Jackson saw only the raw type and decoded JSON objects as LinkedHashMap. With List<String> this was masked because Jackson maps JSON strings natively; List<POJO> degraded silently.

2. Mono<ResponseEntity<List<X>>> path inside handleListResponseSpec passed parameterizedType.getActualTypeArguments()[0] (i.e., the element type X), so respEntity.toEntity produced ResponseEntity<X> instead of ResponseEntity<List<X>>. The existing List<String> test happened to work because Jackson silently coerces JSON arrays to String content, but List<POJO> does not.

Fix: pass the full ParameterizedType (e.g. List<X>) in both branches so Jackson keeps the generic type parameter when materializing the body.

Adds RavenApiClientGenericResponseTests with both Mono<List<POJO>> and Mono<ResponseEntity<List<POJO>>> shapes against a new /getRequest-listPojo[-no-entity] server endpoint, asserting that the deserialized elements are real ServerResponseBody instances with their fields populated. This fails on the previous code and passes after the fix.